### PR TITLE
Added Magento CLI proxy and fixed a few commands in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ A goal of this dev env is to avoid as many host assumptions as possible in order
 ##### MacOS
   
     brew cask install virtualbox
-    brew install vagrant
+    brew cask install vagrant
     vagrant plugin list
     vagrant plugin install vagrant-hostmanager
     vagrant plugin install vagrant-digitalocean

--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ TODO: Describe how to populate DO token, etc, and any changes to Vagrantfile loa
   
     pv database_dump_file.sql | vagrant ssh -c "mysql" -- -q
 
+## Magento CLI Proxy
+
+Normally you would SSH into Vagrant using `vagrant ssh` to run `bin/magento` commands. To make things easier there is a Magento CLI proxy in this package. You can run `bin/magento` commands while in the `devenv` directory and the commands will be proxied to the vagrant vm.
+
 ## Additional Dev Tools
 
 https://atom.io/

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ A goal of this dev env is to avoid as many host assumptions as possible in order
 
 ##### MacOS
   
-    brew install virtualbox
+    brew cask install virtualbox
     brew install vagrant
     vagrant plugin list
     vagrant plugin install vagrant-hostmanager

--- a/bin/magento
+++ b/bin/magento
@@ -1,0 +1,28 @@
+#!/usr/bin/env php
+<?php
+
+// Start command
+$cmd = 'vagrant ssh -c "cd magento; bin/magento';
+
+// remove first arg 'bin/magento'
+array_shift($argv);
+
+// Clear Cache Shortcut, ie bin/magento clear
+if ($argv[0] === 'clear') {
+    $cmd .= " c:c; bin/magento c:f";
+
+// Combine arg array - build normal command args
+} else {
+    foreach ($argv as $v) {
+        $cmd .= " $v";
+    }
+}
+
+// Close command
+$cmd = $cmd . '"';
+
+// Notify Dev
+echo 'Running command: ' . $cmd . PHP_EOL;
+
+// Execute
+echo shell_exec($cmd);


### PR DESCRIPTION
Changes:
* Added Magento CLI proxy script. Allows you to run `bin/magento` from the devenv folder on the host machine to the vagrant vm. 
* Fixed the brew commands for Vagrant and Virtualbox in the README.