### PR TITLE
Add ability to enable/disable MailHog like xDebug

### DIFF
--- a/devenv_shortcuts.sh
+++ b/devenv_shortcuts.sh
@@ -8,21 +8,24 @@ set -eu
 ########################################
 HELP_INFO=$(cat <<'CONTENTS_HEREDOC'
 devenv_shortcuts v0.1
-Copyright (c) 2020, Matt Johnson (matt.johnson@classyllama.com). All 
+Copyright (c) 2020, Matt Johnson (matt.johnson@classyllama.com). All
 rights reserved.
 
 Shortcut commands for common devenv actions
 
 Usage: devenv [command] [command_option]
   xdebug [enable|disable]   Enable of disable PHP xDebug extension
+  mailhog [enable|disable]  Enable or disable MailHog dev email system
 
 Example:
   devenv xdebug enable
   devenv xdebug disable
+  devenv mailhog enable
+  devenv mailhog disable
 
 CONTENTS_HEREDOC
 )
-  
+
 if [ ! $# -ge 1 ]; then
   echo "${HELP_INFO}"
   exit;
@@ -45,6 +48,16 @@ case $1 in
         fi
         COMMAND_OPTION="$2"
         ;;
+    mailhog)
+        COMMAND="mailhog"
+        if [ ! $# -ge 2 ] || [[ ! "$2" =~ ^enable|disable|status ]]; then
+            >&2 echo "Error: Invalid command option given. Valid command options: (enable|disable)"
+            echo ""
+            echo "${HELP_INFO}"
+            exit -1
+        fi
+        COMMAND_OPTION="$2"
+        ;;
     *)
         echo "${HELP_INFO}"
         exit;
@@ -55,7 +68,7 @@ esac
 cd ./source/
 
 if [[ "${COMMAND}" == "xdebug" ]]; then
-  
+
   # Change to provisioning directory to run ansible-playbook commands from
   cd ./provisioning/
 
@@ -73,5 +86,22 @@ if [[ "${COMMAND}" == "xdebug" ]]; then
     [[ "${XDEBUG_STATUS}" != "" ]] \
       && echo "xDebug Enabled" \
       || echo "xDebug Disabled"
+  fi
+elif [[ "${COMMAND}" == "mailhog" ]]; then
+  cd ./provisioning/
+
+  if [[ "${COMMAND_OPTION}" == "enable" ]]; then
+    ansible-playbook -i ../persistent/inventory/devenv action_mailhog_enable.yml --diff
+  elif [[ "${COMMAND_OPTION}" == "disable" ]]; then
+    ansible-playbook -i ../persistent/inventory/devenv action_mailhog_disable.yml --diff
+  elif [[ "${COMMAND_OPTION}" == "status" ]]; then
+    INVENTORY_FILE="../persistent/inventory/devenv"
+    SSH_HOST=$(cat ${INVENTORY_FILE} | perl -ne 'while(/ansible_host=([^\s]+)/g){print "$1";}')
+    SSH_USER=$(cat ${INVENTORY_FILE} | perl -ne 'while(/ansible_user=([^\s]+)/g){print "$1";}')
+    MAILHOG_STATUS=$(ssh -q -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR ${SSH_USER}@${SSH_HOST} "php -i | grep -i 127.0.0.1:1025 | head -1")
+    MAILHOG_STATUS=${XDEBUG_STATUS//[[:space:]]/}
+    [[ "${MAILHOG_STATUS}" != "" ]] \
+      && echo "MailHog Enabled" \
+      || echo "MailHOg Disabled"
   fi
 fi

--- a/provisioning/action_mailhog_disable.yml
+++ b/provisioning/action_mailhog_disable.yml
@@ -59,6 +59,5 @@
       tags: mailhog
       service:
         name: mailhog
-        pattern: /usr/local/bin/MailHog
         enabled: false
         state: stopped

--- a/provisioning/action_mailhog_disable.yml
+++ b/provisioning/action_mailhog_disable.yml
@@ -1,0 +1,64 @@
+---
+- hosts: all
+  name: Disable MailHog
+  become: yes
+
+  vars_files:
+    - ./devenv_vars.default.yml
+    - ./devenv_vars.config.yml
+
+  handlers:
+    - name: restart php-fpm
+      service: name=php-fpm state=restarted
+
+  tasks:
+    - name: Check for existing mailhog ini file
+      tags: mailhog
+      stat:
+          path: "{{ php_mailhog_ini_path }}"
+      register: mailhog_ini_stat
+    
+    - name: Check for disabled mailhog ini file
+      stat:
+          path: "{{ php_mailhog_ini_path }}.disabled"
+      register: mailhog_ini_disabled_stat
+    
+    - name: Configure mailhog.ini
+      tags: mailhog
+      ini_file:
+        section: null
+        dest: "{{ php_mailhog_ini_path }}"
+        option: "{{ item.key }}"
+        value: "{{ item.value }}"
+      with_dict: "{{ php_mailhog_ini }}"
+      notify: restart php-fpm
+      when:
+        - mailhog_ini_stat is not defined or not mailhog_ini_stat.stat.exists
+        - mailhog_ini_disabled_stat is not defined or not mailhog_ini_disabled_stat.stat.exists
+      register: mailhog_ini_created
+
+    - name: Backup existing mailhog ini file as disabled it
+      tags: mailhog
+      copy:
+          remote_src: true
+          src: "{{ php_mailhog_ini_path }}"
+          dest: "{{ php_mailhog_ini_path }}.disabled"
+      when: mailhog_ini_stat.stat.exists
+      notify:
+          - restart php-fpm
+
+    - name: Remove mailhog ini file to disable it
+      tags: mailhog
+      file:
+          path: "{{ php_mailhog_ini_path }}"
+          state: absent
+      notify:
+        - restart php-fpm
+    
+    - name: Disable MailHog system service
+      tags: mailhog
+      service:
+        name: mailhog
+        pattern: /usr/local/bin/MailHog
+        enabled: false
+        state: stopped

--- a/provisioning/action_mailhog_enable.yml
+++ b/provisioning/action_mailhog_enable.yml
@@ -1,0 +1,170 @@
+---
+- hosts: all
+  name: Enable MailHog
+  become: yes
+
+  vars_files:
+    - ./devenv_vars.default.yml
+    - ./devenv_vars.config.yml
+
+  handlers:
+    - name: restart php-fpm
+      service: name=php-fpm state=restarted
+
+  tasks:
+    - name: install msmtp
+      yum: 
+        name: msmtp
+    
+    - name: Check for existing mailhog ini file
+      tags: mailhog
+      stat:
+          path: "{{ php_mailhog_ini_path }}"
+      register: mailhog_ini_stat
+    
+    - name: Check for disabled mailhog ini file
+      tags: mailhog
+      stat:
+          path: "{{ php_mailhog_ini_path }}.disabled"
+      register: mailhog_ini_disabled_stat
+
+    - name: Check for existing MailHog binary
+      tags: mailhog
+      stat:
+        path: "{{ mailhog_install_path }}{{ mailhog_install_name }}"
+      register: mailhog_stat
+    
+    - name: Get current MailHog version (if available)
+      tags: mailhog
+      shell: "{{ mailhog_install_path }}{{ mailhog_install_name }} --version | sed 's/^.* \\(\\([0-9]\\{1,\\}\\.\\)*[0-9]*\\)/\\1/'"
+      when: mailhog_stat.stat and mailhog_stat.stat.exists
+      register: installed_mailhog_version
+    
+    - debug: 
+        var: installed_mailhog_version.stdout
+
+    # Install / Update MailHog if necessary
+    - name: Retrieve latest MailHog release data
+      tags: mailhog
+      uri:
+        url: https://api.github.com/repos/mailhog/MailHog/releases/latest
+        headers:
+          Accept: application/vnd.github.v3+json
+        body_format: json
+        follow_redirects: safe
+      register: latest_mailhog_release_data
+
+    - name: Parse latest MailHog version from data
+      tags: mailhog
+      shell: echo "{{ latest_mailhog_release_data.json.tag_name }}" | sed 's/^v\(\([0-9]\{1,\}\.\)*[0-9]*\).*/\1/g'
+      register: latest_mailhog_release_version
+
+    - name: Retrieve MailHog download path
+      tags: mailhog
+      set_fact:
+        latest_mailhog_download_url: "{{ latest_mailhog_release_data.json | community.general.json_query(latest_amd64_asset_query) }}"
+      vars:
+        latest_amd64_asset_query: "assets[?name==`MailHog_linux_amd64`].browser_download_url | [0]"
+      when:
+        - (installed_mailhog_version.skipped is defined and installed_mailhog_version.skipped) or
+          latest_mailhog_release_version.stdout is version(installed_mailhog_version.stdout, '>')
+    
+    # Download binaries from GitHub
+    - name: Download MailHog binary
+      tags: mailhog
+      get_url:
+        url: "{{ latest_mailhog_download_url }}"
+        dest: "{{ mailhog_install_path }}{{ mailhog_install_name }}"
+      when:
+        - (installed_mailhog_version.skipped is defined and installed_mailhog_version.skipped) or
+          latest_mailhog_release_version.stdout is version(installed_mailhog_version.stdout, '>')
+    
+    - name: Allow execution of MailHog binary
+      tags: mailhog
+      file:
+        path: "{{ mailhog_install_path }}{{ mailhog_install_name }}"
+        mode: 0755
+    
+    # Configure MailHog as system service
+    - name: Check for MailHog system service
+      tags: mailhog
+      stat:
+        path: /etc/systemd/system/mailhog.service
+
+    - name: Configure MailHog service (Unit)
+      tags: mailhog
+      ini_file:
+        section: Unit
+        dest: /etc/systemd/system/mailhog.service
+        option: "{{ item.key }}"
+        value: "{{ item.value }}"
+      with_dict:
+        Description: MailHog
+        After: syslog.target network.target
+      when: mailhog_service_stat is undefined or not mailhog_service_stat.stat.exists
+    
+    - name: Configure MailHog service (Service)
+      tags: mailhog
+      ini_file:
+        section: Service
+        dest: /etc/systemd/system/mailhog.service
+        option: "{{ item.key }}"
+        value: "{{ item.value }}"
+      with_dict:
+        Type: simple
+        ExecStart: "{{ mailhog_install_path }}{{ mailhog_install_name }}"
+        StandardOutput: journal
+        Restart: on-failure
+      when: mailhog_service_stat is undefined or not mailhog_service_stat.stat.exists
+    
+    - name: Configure MailHog service (Install)
+      tags: mailhog
+      ini_file:
+        section: Service
+        dest: /etc/systemd/system/mailhog.service
+        option: "{{ item.key }}"
+        value: "{{ item.value }}"
+      with_dict:
+        WantedBy: multi-user.target
+      when: mailhog_service_stat is undefined or not mailhog_service_stat.stat.exists
+    
+    - name: Enable MailHog system service
+      tags: mailhog
+      service:
+        name: mailhog
+        pattern: /usr/local/bin/MailHog
+        enabled: yes
+        state: started
+    
+    # Create the PHP MailHog configuration file if it doesn't exist at all
+    - name: Configure mailhog.ini.disabled
+      tags: mailhog
+      ini_file:
+        section: null
+        dest: "{{ php_mailhog_ini_path }}.disabled"
+        option: "{{ item.key }}"
+        value: "{{ item.value }}"
+      with_dict: "{{ php_mailhog_ini }}"
+      notify: restart php-fpm
+      when:
+        - mailhog_ini_stat is not defined or not mailhog_ini_stat.stat.exists
+        - mailhog_ini_disabled_stat is not defined or not mailhog_ini_disabled_stat.stat.exists
+      register: mailhog_ini_created
+
+    - name: Copy disabled mailhog.ini file to enable it
+      tags: mailhog
+      copy:
+          remote_src: true
+          src: "{{ php_mailhog_ini_path }}.disabled"
+          dest: "{{ php_mailhog_ini_path }}"
+      when:
+        - (mailhog_ini_created is defined and not mailhog_ini_created.skipped)
+          or mailhog_ini_disabled_stat.stat.exists
+      notify:
+          - restart php-fpm
+
+    - name: Remove disabled mailhog ini file
+      tags: mailhog
+      file:
+          path: "{{ php_mailhog_ini_path }}.disabled"
+          state: absent

--- a/provisioning/action_mailhog_enable.yml
+++ b/provisioning/action_mailhog_enable.yml
@@ -12,9 +12,23 @@
       service: name=php-fpm state=restarted
 
   tasks:
-    - name: install msmtp
+    - name: Install msmtp
+      tags: mailhog
       yum: 
         name: msmtp
+    
+    - name: Create msmtp log file (if necessary)
+      tags: mailhog
+      file:
+        path: "{{ msmtp_log_path }}"
+        state: touch
+        mode: 0666
+
+    - name: Create msmtprc file
+      template:
+        src: msmtp/msmtprc
+        dest: /etc/msmtprc
+        mode: 0644
     
     - name: Check for existing mailhog ini file
       tags: mailhog
@@ -132,7 +146,6 @@
       tags: mailhog
       service:
         name: mailhog
-        pattern: /usr/local/bin/MailHog
         enabled: yes
         state: started
     

--- a/provisioning/devenv_vars.default.yml
+++ b/provisioning/devenv_vars.default.yml
@@ -114,6 +114,12 @@ php_extension_xdebug_ini:
   xdebug.profiler_output_name: cachegrind.out.%s.%t
 php_xdebug_ini_path: "/etc/php.d/15-xdebug.ini"
 
+php_mailhog_ini_path: "/etc/php.d/20-mailhog.ini"
+php_mailhog_ini:
+  sendmail_path: "/usr/bin/msmtp --read-recipients --read-envelope-from --host 127.0.0.1 --port 1025"
+mailhog_install_path: /usr/local/bin/
+mailhog_install_name: MailHog
+
 use_classyllama_repo_python_appstream: false
 python_package_name: python # CentOS 7 uses Python 2.7
 python_software_packages:
@@ -222,7 +228,7 @@ use_vm_cache: true
 composer_selfupdate: false
 
 use_morgangraphics_nvm: true
-morgangraphics_nvm_commands: 
+morgangraphics_nvm_commands:
   - "nvm install node"
   - "npm install -g grunt-cli"
 

--- a/provisioning/devenv_vars.default.yml
+++ b/provisioning/devenv_vars.default.yml
@@ -116,9 +116,10 @@ php_xdebug_ini_path: "/etc/php.d/15-xdebug.ini"
 
 php_mailhog_ini_path: "/etc/php.d/20-mailhog.ini"
 php_mailhog_ini:
-  sendmail_path: "/usr/bin/msmtp --read-recipients --read-envelope-from --host 127.0.0.1 --port 1025"
+  sendmail_path: "/usr/bin/msmtp --read-recipients -a default"
 mailhog_install_path: /usr/local/bin/
 mailhog_install_name: MailHog
+msmtp_log_path: /var/log/msmtp.log
 
 use_classyllama_repo_python_appstream: false
 python_package_name: python # CentOS 7 uses Python 2.7

--- a/provisioning/templates/msmtp/msmtprc
+++ b/provisioning/templates/msmtp/msmtprc
@@ -1,0 +1,14 @@
+# Set default values for all following accounts
+defaults
+auth     off
+tls      off
+logfile  {{ msmtp_log_path }}
+
+# MailHog
+account  mailhog
+host     127.0.0.1
+port     1025
+from     www-data@{{ app_domain }}
+
+# Default account
+account  default : mailhog


### PR DESCRIPTION
Provides scripts to enable or disable MailHog while also downloading (and updating MailHog) if necessary. Adds `msmtp` requirement instead of `mhsendmail` as that project hasn't been updated recently.